### PR TITLE
Add SMTP_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Forgotten Movies keeps Plex requests from gathering dust. It watches Overseerr f
 | `THEMOVIEDB_API_KEY` | Fetches poster artwork for reminder emails. Leave unset to skip artwork (emails still send). |
 | `SMTP_SERVER`, `SMTP_PORT` | SMTP host/port for STARTTLS email delivery (port defaults to 587). |
 | `SMTP_ENCRYPTION` | One of `STARTTLS` (default), `SSL`, or `NONE`. If unset and `SMTP_PORT=465`, the app automatically picks `SSL`. |
+| `SMTP_USERNAME` | Optional SMTP auth username when it differs from `FROM_EMAIL_ADDRESS`. |
 | `FROM_EMAIL_ADDRESS`, `FROM_NAME`, `EMAIL_PASSWORD` | Outbound email identity and password. |
 | `BCC_EMAIL_ADDRESS` | Optional address copied on reminders (you may also set it equal to `FROM_EMAIL_ADDRESS`). |
 | `ADMIN_NAME` | Shown in reminder copy so recipients know who to contact. |
@@ -97,6 +98,7 @@ docker run -d \
   -e SMTP_SERVER="smtp.gmail.com" \
   -e SMTP_PORT=587 \
   -e SMTP_ENCRYPTION="STARTTLS" \
+  -e SMTP_USERNAME="smtp-login@example.com" \
   -e FROM_NAME="Plex Forgotten Movies" \
   -e FROM_EMAIL_ADDRESS="email@gmail.com" \
   -e EMAIL_PASSWORD="password" \
@@ -142,6 +144,7 @@ docker run
   -e 'SMTP_SERVER'='xxxxxxxxx'
   -e 'SMTP_PORT'='587'
   -e 'SMTP_ENCRYPTION'='STARTTLS'
+  -e 'SMTP_USERNAME'='smtp-login@xyz.de'
   -e 'FROM_NAME'='Plex'
   -e 'FROM_EMAIL_ADDRESS'='ab@xyz.de'
   -e 'EMAIL_PASSWORD'='xxxxxxxxxxxxxxxxxx'

--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -17,6 +17,7 @@ services:
       - SMTP_SERVER=smtp.gmail.com
       - SMTP_PORT=587
       - SMTP_ENCRYPTION=STARTTLS # use SSL for implicit TLS (port 465) or NONE to skip encryption
+      - SMTP_USERNAME=smtp-login@example.com # Optional if SMTP auth differs from FROM_EMAIL_ADDRESS
       - FROM_NAME="Plex Forgotten Movies"
       - FROM_EMAIL_ADDRESS=email@gmail.com
       - EMAIL_PASSWORD=password # go make an app password https://myaccount.google.com/apppasswords

--- a/forgotten_movies.py
+++ b/forgotten_movies.py
@@ -918,9 +918,6 @@ def send_email(to_address, subject, body, is_html=False):
         msg['From'] = f"{FROM_NAME} <{from_address}>"
     else:
         msg['From'] = from_address
-    if auth_user and auth_user != from_address:
-        msg['Sender'] = auth_user
-
     # When debugging, redirect the email to ourselves and avoid contacting watchers.
     actual_recipient = to_address
     if DEBUG_MODE:
@@ -965,8 +962,7 @@ def send_email(to_address, subject, body, is_html=False):
                     logger.debug("SMTP login succeeded; sending message to %s.", actual_recipient)
             elif DEBUG_MODE:
                 logger.debug("SMTP credentials missing; sending without AUTH to %s.", actual_recipient)
-            from_addr = auth_user or from_address
-            server.send_message(msg, from_addr=from_addr or None)
+            server.send_message(msg)
             if DEBUG_MODE:
                 try:
                     server.noop()


### PR DESCRIPTION
## Summary
Adds optional `SMTP_USERNAME` for SMTP auth when the auth user differs from the From address.

## Changes
- `forgotten_movies.py`: 
  - add `SMTP_USERNAME`
  - pass explicit `from_addr` to `send_message`
- `README.md`: document `SMTP_USERNAME` and update examples
- `docker-compose.yml-example`: add `SMTP_USERNAME`

## Behavior
- Auth user defaults to `FROM_EMAIL_ADDRESS` if `SMTP_USERNAME` is not set.

## Tests
Tested locally with feature branch image and Zoho Mail (SMTP Pro)

## Notes
Closes #5 

## Preview Image
ghcr.io/phutur1st/forgottenmovies:smtp-username