### PR TITLE
Feat: Self-Service Subscription Management

### DIFF
--- a/forgotten_movies.py
+++ b/forgotten_movies.py
@@ -174,12 +174,13 @@ def build_email_body(
     """Build email body and return (body, unsubscribe_url) tuple."""
     template = load_email_template()
 
-    # Generate unsubscribe URL
-    try:
-        unsubscribe_url = build_unsubscribe_url(email_address)
-    except Exception as exc:
-        logger.warning("Failed to generate unsubscribe URL for %s: %s", email_address, exc)
-        unsubscribe_url = ""
+    # Generate unsubscribe URL (only if feature is enabled)
+    unsubscribe_url = ""
+    if UNSUBSCRIBE_ENABLED:
+        try:
+            unsubscribe_url = build_unsubscribe_url(email_address)
+        except Exception as exc:
+            logger.warning("Failed to generate unsubscribe URL for %s: %s", email_address, exc)
 
     context = SafeDict(
         plex_username=plex_username,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ apscheduler
 gunicorn
 Jinja2>=3.1.3
 filelock>=3.13.1
+itsdangerous>=2.0.0
+Flask-Limiter>=3.0.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -294,10 +294,98 @@
             font-size: 0.9rem;
             color: #777;
         }
+        /* Public page styles (unsubscribe/resubscribe pages) */
+        body.public-page .site-header { display: none; }
+        body.public-page main {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+        }
+        body.public-page .page-title { display: none; }
+        .public-container {
+            max-width: 600px;
+            width: 100%;
+            background: linear-gradient(135deg, #1e1e2f 0%, #24243e 100%);
+            border-radius: 12px;
+            padding: 3rem 2rem;
+            text-align: center;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+        }
+        .public-container .icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+        }
+        .public-container .icon.success { color: #4fc3f7; }
+        .public-container .icon.error { color: #e53935; }
+        .public-container .icon.warning { color: #ff9800; }
+        .public-container h1 {
+            margin: 0 0 1.5rem;
+            font-size: 1.8rem;
+        }
+        .public-container h1.success { color: #4fc3f7; }
+        .public-container h1.error { color: #e53935; }
+        .public-container h1.warning { color: #ff9800; }
+        .public-message {
+            font-size: 1.1rem;
+            line-height: 1.6;
+            margin: 1.5rem 0;
+            color: #c5cae9;
+        }
+        .email-info {
+            color: #9e9e9e;
+            font-size: 0.9rem;
+            margin: 1.5rem 0;
+        }
+        .email-info strong { color: #f5f5f5; }
+        .confirm-button {
+            padding: 0.8rem 2rem;
+            font-size: 1rem;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-weight: 600;
+            transition: background-color 0.2s ease-in-out;
+            margin-top: 1rem;
+        }
+        .confirm-button.primary {
+            background-color: #3f51b5;
+        }
+        .confirm-button.primary:hover { background-color: #5c6bc0; }
+        .confirm-button.danger {
+            background-color: #e53935;
+        }
+        .confirm-button.danger:hover { background-color: #ef5350; }
+        .info-section {
+            margin-top: 2.5rem;
+            padding-top: 2rem;
+            border-top: 1px solid #424245;
+        }
+        .info-section p {
+            font-size: 0.95rem;
+            color: #c5cae9;
+            margin: 0;
+        }
+        .public-footer {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid #424245;
+            font-size: 0.85rem;
+            color: #757575;
+        }
+        .resubscribe-link {
+            display: inline-block;
+            margin-top: 1.5rem;
+            color: #4fc3f7;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .resubscribe-link:hover { text-decoration: underline; }
     </style>
     {% block extra_head %}{% endblock %}
 </head>
-<body>
+<body{% block body_class %}{% endblock %}>
     <header class="site-header">
         <div class="brand">
             <img class="brand-logo" src="{{ url_for('asset', filename='logo.png') }}" alt="Forgotten Movies logo">

--- a/templates/email_template.html
+++ b/templates/email_template.html
@@ -45,6 +45,15 @@
                 </a>
             </div>
         {% endif %}
+
+        {% if unsubscribe_url %}
+            <div style="margin: 32px 0 0 0; padding-top: 16px; border-top: 1px solid #ddd; text-align: center;">
+                <p style="margin: 0; font-size: 12px; color: #666;">
+                    Don't want to receive these reminders?
+                    <a href="{{ unsubscribe_url }}" style="color: #666; text-decoration: underline;">Unsubscribe</a>
+                </p>
+            </div>
+        {% endif %}
     </div>
 </body>
 </html>

--- a/templates/resubscribe_confirm.html
+++ b/templates/resubscribe_confirm.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block body_class %} class="public-page"{% endblock %}
+
+{% block content %}
+<div class="public-container">
+    <div class="icon success">✓</div>
+    <h1 class="success">Confirm Resubscribe</h1>
+
+    <div class="public-message">
+        Would you like to resubscribe to Forgotten Movies reminders?
+    </div>
+
+    {% if email %}
+        <div class="email-info">Email: <strong>{{ email }}</strong></div>
+    {% endif %}
+
+    <form method="POST" action="{{ request.path }}">
+        <button type="submit" class="confirm-button primary">
+            Confirm Resubscribe
+        </button>
+    </form>
+
+    <div class="public-footer">
+        Forgotten Movies
+    </div>
+</div>
+{% endblock %}

--- a/templates/resubscribe_result.html
+++ b/templates/resubscribe_result.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block body_class %} class="public-page"{% endblock %}
+
+{% block content %}
+<div class="public-container">
+    {% if success %}
+        <div class="icon success">✓</div>
+        <h1 class="success">{{ page_title }}</h1>
+    {% else %}
+        <div class="icon error">✗</div>
+        <h1 class="error">{{ page_title }}</h1>
+    {% endif %}
+
+    <div class="public-message">{{ message }}</div>
+
+    {% if email %}
+        <div class="email-info">Email: <strong>{{ email }}</strong></div>
+    {% endif %}
+
+    {% if success %}
+    <div class="info-section">
+        <p>You'll continue receiving reminders about unwatched content you requested.</p>
+    </div>
+    {% endif %}
+
+    <div class="public-footer">
+        Forgotten Movies
+    </div>
+</div>
+{% endblock %}

--- a/templates/unsubscribe_confirm.html
+++ b/templates/unsubscribe_confirm.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block body_class %} class="public-page"{% endblock %}
+
+{% block content %}
+<div class="public-container">
+    <div class="icon warning">⚠️</div>
+    <h1 class="warning">Confirm Unsubscribe</h1>
+
+    <div class="public-message">
+        Are you sure you want to unsubscribe from Forgotten Movies reminders?
+    </div>
+
+    {% if email %}
+        <div class="email-info">Email: <strong>{{ email }}</strong></div>
+    {% endif %}
+
+    <form method="POST" action="{{ request.path }}">
+        <button type="submit" class="confirm-button danger">
+            Confirm Unsubscribe
+        </button>
+    </form>
+
+    <div class="public-footer">
+        Forgotten Movies
+    </div>
+</div>
+{% endblock %}

--- a/templates/unsubscribe_result.html
+++ b/templates/unsubscribe_result.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block body_class %} class="public-page"{% endblock %}
+
+{% block content %}
+<div class="public-container">
+    {% if success %}
+        <div class="icon success">✓</div>
+        <h1 class="success">{{ page_title }}</h1>
+    {% else %}
+        <div class="icon error">✗</div>
+        <h1 class="error">{{ page_title }}</h1>
+    {% endif %}
+
+    <div class="public-message">{{ message }}</div>
+
+    {% if email %}
+        <div class="email-info">Email: <strong>{{ email }}</strong></div>
+    {% endif %}
+
+    {% if success and resubscribe_url %}
+        <a href="{{ resubscribe_url }}" class="resubscribe-link">Changed your mind? Resubscribe</a>
+    {% endif %}
+
+    <div class="public-footer">
+        Forgotten Movies
+    </div>
+</div>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import os
 import time
@@ -15,6 +16,7 @@ from flask import (
     send_from_directory,
     url_for,
 )
+from flask_limiter import Limiter
 
 from forgotten_movies import (
     add_unsubscribed_email,
@@ -34,6 +36,9 @@ from forgotten_movies import (
     set_log_level,
     _attempt_send_request,
     DEBUG_MODE,
+    UNSUBSCRIBE_ENABLED,
+    _decrypt_email,
+    build_resubscribe_url,
 )
 from filelock import Timeout
 
@@ -44,6 +49,79 @@ APP_LOGGER.setLevel(logging.INFO)
 
 app = Flask(__name__)
 app.secret_key = os.getenv("FLASK_SECRET_KEY", "change-me")
+
+# Trusted proxy configuration
+TRUSTED_PROXIES = os.getenv("TRUSTED_PROXIES", "")
+REAL_IP_HEADER = os.getenv("REAL_IP_HEADER", "X-Forwarded-For")
+
+
+def _is_trusted_proxy(ip: str) -> bool:
+    """Check if IP is in the trusted proxy list (supports IPs and CIDRs)."""
+    if not TRUSTED_PROXIES or not ip:
+        return False
+    try:
+        client_ip = ipaddress.ip_address(ip)
+        for trusted in TRUSTED_PROXIES.split(","):
+            trusted = trusted.strip()
+            if not trusted:
+                continue
+            if "/" in trusted:
+                if client_ip in ipaddress.ip_network(trusted, strict=False):
+                    return True
+            else:
+                if client_ip == ipaddress.ip_address(trusted):
+                    return True
+    except ValueError:
+        pass
+    return False
+
+
+def get_real_ip():
+    """Get client IP, trusting forwarded headers only from trusted proxies."""
+    remote = request.remote_addr or "0.0.0.0"
+    if not _is_trusted_proxy(remote):
+        return remote
+    forwarded_for = request.headers.get(REAL_IP_HEADER)
+    if forwarded_for:
+        ip_candidate = forwarded_for.split(",")[0].strip()
+        try:
+            ipaddress.ip_address(ip_candidate)
+            return ip_candidate
+        except ValueError:
+            pass
+    return remote
+
+
+limiter = Limiter(
+    app=app,
+    key_func=get_real_ip,
+    default_limits=[],
+    storage_uri=os.getenv("REDIS_URL", "memory://"),
+    strategy="fixed-window",
+)
+
+
+def _audit_log(action: str, email: str, status: str, reason: str = None):
+    ip_address = get_real_ip()
+    method = request.method
+
+    log_parts = [
+        f"action={action}",
+        f"email={email}",
+        f"ip={ip_address}",
+        f"method={method}",
+        f"status={status}",
+    ]
+    if reason:
+        log_parts.append(f"reason=\"{reason}\"")
+
+    log_message = " ".join(log_parts)
+
+    if status == "success":
+        APP_LOGGER.info("AUDIT: %s", log_message)
+    else:
+        APP_LOGGER.warning("AUDIT: %s", log_message)
+
 
 BASE_DIR = os.path.dirname(__file__)
 FILES_DIR = os.path.join(BASE_DIR, "files")
@@ -98,10 +176,7 @@ def trigger_job(reason: str, async_run: bool) -> tuple[bool, str]:
         ).start()
         return True, "Job started."
 
-    try:
-        _target(lock)
-    finally:
-        pass
+    _target(lock)
     return True, "Job started."
 
 
@@ -130,6 +205,7 @@ def index():
     unsubscribe_records = _format_unsubscribe_records(list_unsubscribed_emails())
     unsubscribe_messages: list[tuple[str, str]] = []
     messages = []
+
     for category, text in get_flashed_messages(with_categories=True):
         if category.startswith("unsubscribe-"):
             unsubscribe_messages.append((category, text))
@@ -189,16 +265,22 @@ def send_request_now(request_id):
     now = datetime.now()
     user_record = get_email_user(email_value)
     APP_LOGGER.info("Manual action: send-now requested for %s (request %s)", email_value, identifier)
-    outcome = _attempt_send_request(
-        record,
-        {},
-        user_record=user_record,
-        respect_cycle=False,
-        respect_cooldown=False,
-        perform_db_updates=not DEBUG_MODE,
-        allow_sleep=False,
-        now_dt=now,
-    )
+
+    try:
+        outcome = _attempt_send_request(
+            record,
+            {},
+            user_record=user_record,
+            respect_cycle=False,
+            respect_cooldown=False,
+            perform_db_updates=not DEBUG_MODE,
+            allow_sleep=False,
+            now_dt=now,
+        )
+    except Exception as exc:
+        APP_LOGGER.exception("Failed to send email for request %s: %s", identifier, exc)
+        flash(f"Failed to send email: {str(exc)}", "todo-error")
+        return redirect(url_for("index", _anchor="todo-card"))
 
     if not outcome.sent:
         APP_LOGGER.info("Send-now skipped for request %s: %s", identifier, outcome.message)
@@ -222,8 +304,8 @@ def unsubscribe_email():
             return jsonify({"success": False, "message": message})
         flash(message, "unsubscribe-error")
         return redirect(url_for("index"))
-    APP_LOGGER.info("Manual action: unsubscribing %s", email)
     add_unsubscribed_email(email)
+    _audit_log(action="manual_unsubscribe", email=email, status="success")
     updated_record = get_email_user(email)
     formatted = (
         _format_unsubscribe_records([dict(updated_record)]) if updated_record else []
@@ -257,18 +339,168 @@ def remove_email():
         return redirect(url_for("index"))
     removed = remove_unsubscribed_email(email)
     if removed:
-        APP_LOGGER.info("Manual action: removed %s from unsubscribe list", email)
+        _audit_log(action="remove_from_unsubscribe_list", email=email, status="success")
         message = f"Removed {email} from the unsubscribe list."
         if wants_json:
             return jsonify({"success": True, "message": message, "email": email})
         flash(message, "unsubscribe-success")
     else:
-        APP_LOGGER.info("Manual action: attempted removal for %s but it was not listed", email)
+        _audit_log(
+            action="remove_from_unsubscribe_list",
+            email=email,
+            status="not_found",
+            reason="Email was not in unsubscribe list"
+        )
         message = f"{email} was not on the unsubscribe list."
         if wants_json:
             return jsonify({"success": False, "message": message, "email": email})
         flash(message, "unsubscribe-info")
     return redirect(url_for("index"))
+
+
+@app.route("/unsubscribe/<token>", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
+def unsubscribe_via_link(token: str):
+    if not UNSUBSCRIBE_ENABLED:
+        APP_LOGGER.warning("Unsubscribe endpoint accessed but feature is disabled")
+        if request.method == "POST":
+            return "Feature disabled", 404
+        return render_template(
+            "unsubscribe_result.html",
+            page_title="Feature Disabled",
+            success=False,
+            email=None,
+            message="Self-service unsubscribe is not enabled. Please contact the administrator.",
+            current_year=time.strftime("%Y"),
+        ), 404
+
+    try:
+        decoded_email = _decrypt_email(token).strip().lower()
+    except Exception as exc:
+        _audit_log(
+            action="unsubscribe_attempt",
+            email="<invalid_token>",
+            status="failure",
+            reason=f"Token decrypt failed: {exc}"
+        )
+        if request.method == "POST":
+            return "Invalid or expired token", 400
+        return render_template(
+            "unsubscribe_result.html",
+            page_title="Invalid or Expired Link",
+            success=False,
+            email=None,
+            message="This unsubscribe link is invalid or has expired. Links expire after 90 days.",
+            current_year=time.strftime("%Y"),
+        ), 400
+
+    if request.method == "GET":
+        return render_template(
+            "unsubscribe_confirm.html",
+            token=token,
+            email=decoded_email,
+            current_year=time.strftime("%Y"),
+        )
+
+    is_one_click = request.form.get('List-Unsubscribe') == 'One-Click'
+
+    add_unsubscribed_email(decoded_email)
+    method_type = "one-click" if is_one_click else "web_form"
+    _audit_log(action=f"unsubscribe_{method_type}", email=decoded_email, status="success")
+
+    # RFC 8058 one-click: minimal response for email client compatibility
+    if is_one_click:
+        return "", 200
+
+    try:
+        resubscribe_url = build_resubscribe_url(decoded_email)
+    except Exception as exc:
+        APP_LOGGER.warning("Failed to generate resubscribe URL: %s", exc)
+        resubscribe_url = None
+
+    return render_template(
+        "unsubscribe_result.html",
+        page_title="Unsubscribed Successfully",
+        success=True,
+        email=decoded_email,
+        message="You have been unsubscribed from Forgotten Movies reminders.",
+        resubscribe_url=resubscribe_url,
+        current_year=time.strftime("%Y"),
+    )
+
+
+@app.route("/resubscribe/<token>", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
+def resubscribe_via_link(token: str):
+    if not UNSUBSCRIBE_ENABLED:
+        APP_LOGGER.warning("Resubscribe endpoint accessed but feature is disabled")
+        if request.method == "POST":
+            return "Feature disabled", 404
+        return render_template(
+            "resubscribe_result.html",
+            page_title="Feature Disabled",
+            success=False,
+            email=None,
+            message="Self-service unsubscribe is not enabled. Please contact the administrator.",
+            current_year=time.strftime("%Y"),
+        ), 404
+
+    try:
+        decoded_email = _decrypt_email(token).strip().lower()
+    except Exception as exc:
+        _audit_log(
+            action="resubscribe_attempt",
+            email="<invalid_token>",
+            status="failure",
+            reason=f"Token decrypt failed: {exc}"
+        )
+        if request.method == "POST":
+            return "Invalid or expired token", 400
+        return render_template(
+            "resubscribe_result.html",
+            page_title="Invalid or Expired Link",
+            success=False,
+            email=None,
+            message="This resubscribe link is invalid or has expired. Links expire after 90 days.",
+            current_year=time.strftime("%Y"),
+        ), 400
+
+    if request.method == "GET":
+        return render_template(
+            "resubscribe_confirm.html",
+            token=token,
+            email=decoded_email,
+            current_year=time.strftime("%Y"),
+        )
+
+    was_unsubscribed = remove_unsubscribed_email(decoded_email)
+
+    if not was_unsubscribed:
+        _audit_log(
+            action="resubscribe",
+            email=decoded_email,
+            status="already_subscribed",
+            reason="Email was not in unsubscribe list"
+        )
+        return render_template(
+            "resubscribe_result.html",
+            page_title="Already Subscribed",
+            success=True,
+            email=decoded_email,
+            message="You are already subscribed to Forgotten Movies reminders.",
+            current_year=time.strftime("%Y"),
+        )
+
+    _audit_log(action="resubscribe", email=decoded_email, status="success")
+
+    return render_template(
+        "resubscribe_result.html",
+        page_title="Resubscribed Successfully",
+        success=True,
+        email=decoded_email,
+        message="You have been resubscribed to Forgotten Movies reminders.",
+        current_year=time.strftime("%Y"),
+    )
 
 
 @app.route("/run-now", methods=["POST"])
@@ -370,3 +602,21 @@ def update_watch_status():
         APP_LOGGER.exception("Watch status check failed: %s", exc)
         flash(f"Watch status check failed: {exc}", "error")
     return redirect(url_for("settings"))
+
+
+@app.errorhandler(429)
+def ratelimit_handler(e):
+    APP_LOGGER.warning("Rate limit exceeded for %s: %s", get_real_ip(), request.path)
+
+    # RFC 8058 one-click: minimal response for email client compatibility
+    if request.method == "POST" and request.path.startswith("/unsubscribe"):
+        return "Rate limit exceeded. Please try again later.", 429
+
+    return render_template(
+        "unsubscribe_result.html",
+        page_title="Too Many Requests",
+        success=False,
+        email=None,
+        message="You have made too many requests. Please wait a moment and try again.",
+        current_year=time.strftime("%Y"),
+    ), 429


### PR DESCRIPTION
## Summary

Add optional self-service subscription management allowing users to unsubscribe/resubscribe via secure links in reminder emails, reducing admin overhead.

**Key changes:**
- RFC 8058 one-click unsubscribe support (`List-Unsubscribe` and `List-Unsubscribe-Post` headers)
- Cryptographically signed tokens via `itsdangerous` with 90-day expiry
- Public confirmation pages that work behind any reverse proxy
- App-level rate limiting (10 req/min per IP) via Flask-Limiter
- Trusted proxy support for accurate client IP detection
- Optional Redis backend for multi-instance deployments
- Audit logging for all subscription actions

**Additional fix:**
- Graceful error handling for manual email sends - SMTP failures display in dashboard instead of server error page (`webapp.py:280-283`)

## New Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `UNSUBSCRIBE_SECRET_KEY` | Secret key for signing tokens. Leave unset to disable feature. | - |
| `BASE_URL` | Public HTTPS URL (e.g., `https://forgotten.example.com`) | - |
| `TRUSTED_PROXIES` | Comma-separated IPs/CIDRs of reverse proxies | - |
| `REAL_IP_HEADER` | Header containing client IP | `X-Forwarded-For` |
| `REDIS_URL` | Optional Redis URL for rate limiting storage | `memory://` |

## Security

- Tokens are HMAC-signed and validated server-side
- List-Unsubscribe headers only added for HTTPS URLs (per RFC 8058)
- Rate limiting prevents enumeration attacks
- Trusted proxy validation prevents spoofed header bypass

## Email Deliverability Note

For optimal inbox placement, ensure your sending domain has SPF, DKIM, and DMARC configured.

**References:**
- [RFC 8058 - One-Click Unsubscribe](https://datatracker.ietf.org/doc/html/rfc8058)
- [Google Email Sender Guidelines](https://support.google.com/mail/answer/81126)
- [Apple iCloud Mail Postmaster Information](https://support.apple.com/en-us/102322)

## Test Plan

- [x] Verify emails send without unsubscribe links when feature disabled
- [x] Enable feature, verify `List-Unsubscribe` headers present (HTTPS only)
- [x] Test unsubscribe flow: link → confirm → success
- [x] Test resubscribe flow: link → confirm → removed from list
- [x] Test expired token (>90 days) returns error
- [x] Test rate limiting with `TRUSTED_PROXIES` configured
- [x] Verify audit logs show correct client IP behind proxy
- [x] Test manual send with invalid SMTP config - should show error in dashboard, not 500

## Test Image

`ghcr.io/phutur1st/forgottenmovies:subscription-mgmt`